### PR TITLE
make messages fields use interface for extensibility

### DIFF
--- a/tests/messages/test_abort.py
+++ b/tests/messages/test_abort.py
@@ -1,7 +1,7 @@
 import pytest
 
 from wampproto.messages import util
-from wampproto.messages.abort import Abort
+from wampproto.messages.abort import Abort, AbortFields
 
 
 def test_parse_with_invalid_type():
@@ -79,7 +79,7 @@ def test_parse_correctly():
 
 def test_marshal_with_empty_details():
     reason = "wamp.error.no_such_realm"
-    message = Abort({}, reason).marshal()
+    message = Abort(AbortFields({}, reason)).marshal()
 
     assert isinstance(message, list)
 
@@ -95,7 +95,7 @@ def test_marshal_with_empty_details():
 def test_marshal_with_details():
     details = {"message": "The realm does not exist."}
     reason = "wamp.error.no_such_realm"
-    message = Abort(details, reason).marshal()
+    message = Abort(AbortFields(details, reason)).marshal()
 
     assert isinstance(message, list)
 

--- a/tests/messages/test_authenticate.py
+++ b/tests/messages/test_authenticate.py
@@ -1,7 +1,7 @@
 import pytest
 
 from wampproto.messages import util
-from wampproto.messages import Authenticate
+from wampproto.messages.authenticate import Authenticate, AuthenticateFields
 
 
 def test_parse_with_invalid_type():
@@ -72,7 +72,7 @@ def test_parse_correctly():
 
 def test_marshal_without_extra():
     signature = "signature"
-    message = Authenticate(signature).marshal()
+    message = Authenticate(AuthenticateFields(signature)).marshal()
 
     assert isinstance(message, list)
 
@@ -88,7 +88,7 @@ def test_marshal_without_extra():
 def test_marshal_with_extra():
     signature = "signature"
     extra = {"channel_binding": "null"}
-    message = Authenticate(signature, extra).marshal()
+    message = Authenticate(AuthenticateFields(signature, extra)).marshal()
 
     assert isinstance(message, list)
 

--- a/tests/messages/test_hello.py
+++ b/tests/messages/test_hello.py
@@ -1,14 +1,14 @@
 import pytest
 
 from wampproto.messages import util
-from wampproto.messages.hello import Hello
+from wampproto.messages.hello import Hello, HelloFields
 
 
 def test_marshal_with_no_roles_and_details():
     realm = "realm"
     roles = {}
     details = {}
-    message = Hello(realm, roles, **details).marshal()
+    message = Hello(HelloFields(realm, roles, **details)).marshal()
 
     assert isinstance(message, list)
     assert len(message) == 3
@@ -27,7 +27,7 @@ def test_marshal_with_role_and_no_details():
     realm = "realm"
     roles = {"callee": {}}
     details = {}
-    message = Hello(realm, roles, **details).marshal()
+    message = Hello(HelloFields(realm, roles, **details)).marshal()
 
     assert isinstance(message, list)
     assert len(message) == 3
@@ -46,7 +46,7 @@ def test_marshal_with_authid():
     realm = "realm"
     roles = {"callee": {}}
     details = {"authid": "mahad"}
-    message = Hello(realm, roles, **details).marshal()
+    message = Hello(HelloFields(realm, roles, **details)).marshal()
 
     assert isinstance(message, list)
     assert len(message) == 3
@@ -65,7 +65,7 @@ def test_marshal_with_authrole():
     realm = "realm"
     roles = {"callee": {}}
     details = {"authrole": "admin"}
-    message = Hello(realm, roles, **details).marshal()
+    message = Hello(HelloFields(realm, roles, **details)).marshal()
 
     assert isinstance(message, list)
     assert len(message) == 3
@@ -84,7 +84,7 @@ def test_marshal_with_authmethods():
     realm = "realm"
     roles = {"callee": {}}
     details = {"authmethods": ["ticket"]}
-    message = Hello(realm, roles, **details).marshal()
+    message = Hello(HelloFields(realm, roles, **details)).marshal()
 
     assert isinstance(message, list)
     assert len(message) == 3
@@ -103,7 +103,7 @@ def test_marshal_with_authextra():
     realm = "realm"
     roles = {"callee": {}}
     details = {"authextra": {"authproivder": "static"}}
-    message = Hello(realm, roles, **details).marshal()
+    message = Hello(HelloFields(realm, roles, **details)).marshal()
 
     assert isinstance(message, list)
     assert len(message) == 3
@@ -122,7 +122,7 @@ def test_marshal_with_role_authid_and_authrole():
     realm = "realm"
     roles = {"callee": {}}
     details = {"authid": "mahad", "authrole": "admin"}
-    message = Hello(realm, roles, **details).marshal()
+    message = Hello(HelloFields(realm, roles, **details)).marshal()
 
     assert isinstance(message, list)
     assert len(message) == 3
@@ -141,7 +141,7 @@ def test_marshal_with_role_authid_authrole_authmethods():
     realm = "realm"
     roles = {"callee": {}}
     details = {"authid": "mahad", "authrole": "admin", "authmethods": ["ticket"]}
-    message = Hello(realm, roles, **details).marshal()
+    message = Hello(HelloFields(realm, roles, **details)).marshal()
 
     assert isinstance(message, list)
     assert len(message) == 3
@@ -160,7 +160,7 @@ def test_marshal_with_role_authid_authrole_authmethods_authextra():
     realm = "realm"
     roles = {"callee": {}}
     details = {"authid": "mahad", "authrole": "admin", "authmethods": ["ticket"], "authextra": {"extra": True}}
-    message = Hello(realm, roles, **details).marshal()
+    message = Hello(HelloFields(realm, roles, **details)).marshal()
 
     assert isinstance(message, list)
     assert len(message) == 3

--- a/tests/messages/test_welcome.py
+++ b/tests/messages/test_welcome.py
@@ -299,7 +299,7 @@ def test_parse_with_empty_role():
     assert (
         str(exc_info.value)
         == f"{Welcome.TEXT}: value at index 2 for roles key must be in {util.AllowedRoles.get_allowed_roles()} "
-           f"but was empty"
+        f"but was empty"
     )
 
 
@@ -311,7 +311,7 @@ def test_parse_with_invalid_role_key():
     assert (
         str(exc_info.value)
         == f"{Welcome.TEXT}: value at index 2 for roles key must be in {util.AllowedRoles.get_allowed_roles()} "
-           f"but was new_role"
+        f"but was new_role"
     )
 
 

--- a/wampproto/auth/cryptosign.py
+++ b/wampproto/auth/cryptosign.py
@@ -6,6 +6,7 @@ from nacl.encoding import HexEncoder
 from nacl.exceptions import BadSignatureError
 
 from wampproto import messages, auth
+from wampproto.messages.authenticate import AuthenticateFields
 
 
 class CryptoSignAuthenticator(auth.IClientAuthenticator):
@@ -26,7 +27,7 @@ class CryptoSignAuthenticator(auth.IClientAuthenticator):
 
         signed = sign_cryptosign_challenge(challenge_hex, self._private_key)
 
-        return messages.Authenticate(signed + challenge_hex, {})
+        return messages.Authenticate(AuthenticateFields(signed + challenge_hex, {}))
 
 
 def generate_cryptosign_challenge() -> str:

--- a/wampproto/auth/ticket.py
+++ b/wampproto/auth/ticket.py
@@ -1,4 +1,5 @@
 from wampproto import messages, auth
+from wampproto.messages.authenticate import AuthenticateFields
 
 
 class TicketAuthenticator(auth.IClientAuthenticator):
@@ -9,4 +10,4 @@ class TicketAuthenticator(auth.IClientAuthenticator):
         self._ticket = ticket
 
     def authenticate(self, challenge: messages.Challenge) -> messages.Authenticate:
-        return messages.Authenticate(self._ticket, {})
+        return messages.Authenticate(AuthenticateFields(self._ticket, {}))

--- a/wampproto/auth/wampcra.py
+++ b/wampproto/auth/wampcra.py
@@ -7,6 +7,7 @@ import json
 import random
 
 from wampproto import messages, auth
+from wampproto.messages.authenticate import AuthenticateFields
 
 
 class WAMPCRAAuthenticator(auth.IClientAuthenticator):
@@ -18,7 +19,7 @@ class WAMPCRAAuthenticator(auth.IClientAuthenticator):
 
     def authenticate(self, challenge: messages.Challenge) -> messages.Authenticate:
         signed = sign_wampcra_challenge(challenge.extra["challenge"], self._secret.encode())
-        return messages.Authenticate(signed, {})
+        return messages.Authenticate(AuthenticateFields(signed, {}))
 
 
 def utcnow() -> str:

--- a/wampproto/joiner.py
+++ b/wampproto/joiner.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from wampproto import messages, serializers, auth
 from wampproto.types import SessionDetails
+from wampproto.messages.hello import HelloFields
 
 CLIENT_ROLES = {
     "caller": {"features": {}},
@@ -35,11 +36,13 @@ class Joiner:
             roles = CLIENT_ROLES
 
         hello = messages.Hello(
-            realm=self._realm,
-            roles=roles,
-            authid=self._authenticator.authid,
-            authmethods=[self._authenticator.auth_method],
-            authextra=self._authenticator.auth_extra,
+            HelloFields(
+                realm=self._realm,
+                roles=roles,
+                authid=self._authenticator.authid,
+                authmethods=[self._authenticator.auth_method],
+                authextra=self._authenticator.auth_extra,
+            )
         )
 
         self._state = Joiner.STATE_HELLO_SENT

--- a/wampproto/messages/abort.py
+++ b/wampproto/messages/abort.py
@@ -7,6 +7,31 @@ from wampproto.messages.message import Message
 from wampproto.messages.validation_spec import ValidationSpec
 
 
+class IAbortFields:
+    @property
+    def details(self):
+        raise NotImplementedError()
+
+    @property
+    def reason(self):
+        raise NotImplementedError()
+
+
+class AbortFields(IAbortFields):
+    def __init__(self, details: dict, reason: str):
+        super().__init__()
+        self._details = details
+        self._reason = reason
+
+    @property
+    def details(self):
+        return self._details
+
+    @property
+    def reason(self):
+        return self._reason
+
+
 class Abort(Message):
     TEXT = "ABORT"
     TYPE = 3
@@ -21,15 +46,22 @@ class Abort(Message):
         },
     )
 
-    def __init__(self, details: dict, reason: str):
+    def __init__(self, fields: IAbortFields):
         super().__init__()
-        self.details = details
-        self.reason = reason
+        self._fields = fields
+
+    @property
+    def details(self) -> dict:
+        return self._fields.details
+
+    @property
+    def reason(self) -> str:
+        return self._fields.reason
 
     @classmethod
     def parse(cls, msg: list[Any]) -> Abort:
         f = util.validate_message(msg, cls.TYPE, cls.TEXT, cls.VALIDATION_SPEC)
-        return Abort(f.details, f.reason)
+        return Abort(AbortFields(f.details, f.reason))
 
     def marshal(self) -> list[Any]:
         return [self.TYPE, self.details, self.reason]

--- a/wampproto/messages/hello.py
+++ b/wampproto/messages/hello.py
@@ -7,6 +7,75 @@ from wampproto.messages.message import Message
 from wampproto.messages.validation_spec import ValidationSpec
 
 
+class IHelloFields:
+    @property
+    def realm(self) -> str:
+        raise NotImplementedError()
+
+    @property
+    def roles(self) -> dict[str, Any]:
+        raise NotImplementedError()
+
+    @property
+    def authid(self) -> str:
+        raise NotImplementedError()
+
+    @property
+    def authrole(self) -> str:
+        raise NotImplementedError()
+
+    @property
+    def authmethods(self) -> list[str]:
+        raise NotImplementedError()
+
+    @property
+    def authextra(self) -> dict:
+        raise NotImplementedError()
+
+
+class HelloFields(IHelloFields):
+    def __init__(
+        self,
+        realm: str,
+        roles: dict[str, Any],
+        authid: str | None = None,
+        authrole: str | None = None,
+        authmethods: list[str] | None = None,
+        authextra: dict | None = None,
+    ):
+        super().__init__()
+        self._realm = realm
+        self._roles = roles
+        self._authid = authid
+        self._authrole = authrole
+        self._authmethods = authmethods
+        self._authextra = authextra
+
+    @property
+    def realm(self) -> str:
+        return self._realm
+
+    @property
+    def roles(self) -> dict[str, Any]:
+        return self._roles
+
+    @property
+    def authid(self) -> str:
+        return self._authid
+
+    @property
+    def authrole(self) -> str:
+        return self._authrole
+
+    @property
+    def authmethods(self) -> list[str]:
+        return self._authmethods
+
+    @property
+    def authextra(self) -> dict:
+        return self._authextra
+
+
 class Hello(Message):
     TEXT = "HELLO"
     TYPE = 1
@@ -21,33 +90,46 @@ class Hello(Message):
         },
     )
 
-    def __init__(
-        self,
-        realm: str,
-        roles: dict[str, Any],
-        authid: str | None = None,
-        authrole: str | None = None,
-        authmethods: list[str] | None = None,
-        authextra: dict | None = None,
-    ):
+    def __init__(self, fields: IHelloFields):
         super().__init__()
-        self.realm = realm
-        self.roles = roles
-        self.authid = authid
-        self.authrole = authrole
-        self.authmethods = authmethods
-        self.authextra = authextra
+        self._fields = fields
+
+    @property
+    def realm(self) -> str:
+        return self._fields.realm
+
+    @property
+    def roles(self) -> dict[str, Any]:
+        return self._fields.roles
+
+    @property
+    def authid(self) -> str:
+        return self._fields.authid
+
+    @property
+    def authrole(self) -> str:
+        return self._fields.authrole
+
+    @property
+    def authmethods(self) -> list[str]:
+        return self._fields.authmethods
+
+    @property
+    def authextra(self) -> dict:
+        return self._fields.authextra
 
     @classmethod
     def parse(cls, msg: list[Any]) -> Hello:
         f = util.validate_message(msg, cls.TYPE, cls.TEXT, cls.VALIDATION_SPEC)
         return Hello(
-            realm=f.realm,
-            roles=f.roles,
-            authid=f.authid,
-            authrole=f.authrole,
-            authmethods=f.authmethods,
-            authextra=f.authextra,
+            HelloFields(
+                realm=f.realm,
+                roles=f.roles,
+                authid=f.authid,
+                authrole=f.authrole,
+                authmethods=f.authmethods,
+                authextra=f.authextra,
+            )
         )
 
     def marshal(self) -> list[Any]:


### PR DESCRIPTION
change is first of its kind. Needs to happen in all WAMP message types. Doing this allows us to use WAMP message definitions with Flatbuffers, Cap'nProto etc...